### PR TITLE
Modify http headers on GEB to bypass crowdsegment authentication

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,6 +43,8 @@ dependencies {
     // JSON simple for MuukReport
     implementation group: 'com.googlecode.json-simple', name: 'json-simple', version: '1.1.1' 
 
+    //implementation group: 'net.lightbody.bmp', name: 'browsermob-proxy', version: '2.1.5'
+    compile group: 'net.lightbody.bmp', name: 'browsermob-core', version: '2.1.5'    
 }
 
 webdriverBinaries {

--- a/src/test/resources/GebConfig.groovy
+++ b/src/test/resources/GebConfig.groovy
@@ -1,12 +1,20 @@
 // This is the Geb configuration file.
 // See: http://www.gebish.org/manual/current/#configuration
 
-
-import org.openqa.selenium.chrome.ChromeDriver
-import org.openqa.selenium.chrome.ChromeOptions
-import org.openqa.selenium.firefox.FirefoxDriver
-import org.openqa.selenium.remote.DesiredCapabilities
-import org.openqa.selenium.remote.CapabilityType
+import org.openqa.selenium.chrome.ChromeDriver;
+import org.openqa.selenium.chrome.ChromeOptions;
+import org.openqa.selenium.firefox.FirefoxDriver;
+import io.netty.handler.codec.http.DefaultHttpHeaders;
+import io.netty.handler.codec.http.HttpRequest;
+import io.netty.handler.codec.http.HttpResponse;
+import net.lightbody.bmp.BrowserMobProxy;
+import net.lightbody.bmp.BrowserMobProxyServer;
+import net.lightbody.bmp.client.ClientUtil;
+import net.lightbody.bmp.filters.RequestFilter;
+import net.lightbody.bmp.util.HttpMessageContents;
+import net.lightbody.bmp.util.HttpMessageInfo;
+import org.openqa.selenium.remote.CapabilityType;
+import org.openqa.selenium.firefox.FirefoxOptions;
 
 waiting {
   timeout = 20
@@ -16,17 +24,43 @@ environments {
   // run via “./gradlew chromeTest”
   // See: http://code.google.com/p/selenium/wiki/ChromeDriver
   chrome {
-    driver = {
-      ChromeOptions o = new ChromeOptions()
-      o.addArguments('--no-sandbox');
-      o.addArguments('--disable-dev-shm-usage');
-      o.addArguments("--ignore-certificate-errors");
-      DesiredCapabilities cap=DesiredCapabilities.chrome();
-      cap.setCapability(ChromeOptions.CAPABILITY, o);
-      cap.setCapability(CapabilityType.ACCEPT_SSL_CERTS, true);
-      cap.setCapability(CapabilityType.ACCEPT_INSECURE_CERTS, true);
-      new ChromeDriver(cap);
-    }
+
+    /*
+      BrowserMob Proxy allows you to manipulate HTTP requests and responses.
+      This proxy help us to add ClinetID and Secret to bypass cloudflare 
+      authentication on Steppingblocks tests.
+    */
+    BrowserMobProxyServer browserMobProxy = new BrowserMobProxyServer();
+    browserMobProxy.setTrustAllServers(true);
+    browserMobProxy.start(0);
+    browserMobProxy.addRequestFilter(new RequestFilter() {
+        @Override
+        public HttpResponse filterRequest(HttpRequest httpRequest, HttpMessageContents httpMessageContents, HttpMessageInfo httpMessageInfo) {
+            if(httpMessageInfo.getUrl().toString().contains("qa.crowdsegment.com/login")){
+                DefaultHttpHeaders httpHeaders = new DefaultHttpHeaders();
+                httpHeaders.add("CF-Access-Client-ID", "CLIENT_VALUE");
+                httpHeaders.add("CF-Access-Client-Secret", "SECRET_VALUE");
+                httpRequest.headers().add(httpHeaders);
+            }
+            else if(httpMessageInfo.getUrl().toString().contains("staging.crowdsegment.com/login")){
+                DefaultHttpHeaders httpHeaders = new DefaultHttpHeaders();
+                httpHeaders.add("CF-Access-Client-ID", "CLIENT_VALUE");
+                httpHeaders.add("CF-Access-Client-Secret", "SECRET_VALUE");
+                httpRequest.headers().add(httpHeaders);
+            }
+            return null;
+        }
+    });
+
+    ChromeOptions o = new ChromeOptions()
+    o.addArguments('--no-sandbox');
+    o.addArguments('--disable-dev-shm-usage');
+
+    // Set proxy on chrome options.
+    o.setCapability(CapabilityType.PROXY, ClientUtil.createSeleniumProxy(browserMobProxy));
+    o.addArguments("--ignore-certificate-errors");
+    
+    driver = { new ChromeDriver(o) }
   }
 
   // run via “./gradlew chromeHeadlessTest”
@@ -38,14 +72,47 @@ environments {
       new ChromeDriver(o)
     }
   }
-
+	
   // run via “./gradlew firefoxTest”
   // See: http://code.google.com/p/selenium/wiki/FirefoxDriver
   firefox {
+
+     /*
+      BrowserMob Proxy allows you to manipulate HTTP requests and responses.
+      This proxy help us to add ClinetID and Secret to bypass cloudflare 
+      authentication on Steppingblocks tests.
+    */
+    BrowserMobProxyServer browserMobProxy = new BrowserMobProxyServer();
+    browserMobProxy.setTrustAllServers(true);
+    browserMobProxy.start(0);
+    browserMobProxy.addRequestFilter(new RequestFilter() {
+        @Override
+        public HttpResponse filterRequest(HttpRequest httpRequest, HttpMessageContents httpMessageContents, HttpMessageInfo httpMessageInfo) {
+           if(httpMessageInfo.getUrl().toString().contains("qa.crowdsegment.com/login")){
+                DefaultHttpHeaders httpHeaders = new DefaultHttpHeaders();
+                httpHeaders.add("CF-Access-Client-ID", "CLIENT_VALUE");
+                httpHeaders.add("CF-Access-Client-Secret", "SECRET_VALUE");
+                httpRequest.headers().add(httpHeaders);
+            }
+            else if(httpMessageInfo.getUrl().toString().contains("staging.crowdsegment.com/login")){
+                DefaultHttpHeaders httpHeaders = new DefaultHttpHeaders();
+                httpHeaders.add("CF-Access-Client-ID", "CLIENT_VALUE");
+                httpHeaders.add("CF-Access-Client-Secret", "SECRET_VALUE");
+                httpRequest.headers().add(httpHeaders);
+            }
+            return null;
+        }
+    });
+
     atCheckWaiting = 1
-    driver = { new FirefoxDriver() }
+
+    // Set proxy on firefox options.
+    FirefoxOptions firefoxOptions = new FirefoxOptions();
+    firefoxOptions.setCapability(CapabilityType.PROXY, ClientUtil.createSeleniumProxy(browserMobProxy));
+    driver = { new FirefoxDriver(firefoxOptions) }
   }
 }
 
 // To run the tests with all browsers just run “./gradlew test”
 baseUrl = "http://gebish.org"
+

--- a/src/test/resources/GebConfig.groovy
+++ b/src/test/resources/GebConfig.groovy
@@ -48,6 +48,12 @@ environments {
                 httpHeaders.add("CF-Access-Client-Secret", "SECRET_VALUE");
                 httpRequest.headers().add(httpHeaders);
             }
+            else if(httpMessageInfo.getUrl().toString().contains("staging.steppingblocks.com/login")){
+                DefaultHttpHeaders httpHeaders = new DefaultHttpHeaders();
+                httpHeaders.add("CF-Access-Client-ID", "CLIENT_VALUE");
+                httpHeaders.add("CF-Access-Client-Secret", "SECRET_VALUE");
+                httpRequest.headers().add(httpHeaders);
+            }
             return null;
         }
     });
@@ -100,6 +106,12 @@ environments {
                 httpHeaders.add("CF-Access-Client-Secret", "SECRET_VALUE");
                 httpRequest.headers().add(httpHeaders);
             }
+            else if(httpMessageInfo.getUrl().toString().contains("staging.steppingblocks.com/login")){
+                DefaultHttpHeaders httpHeaders = new DefaultHttpHeaders();
+                httpHeaders.add("CF-Access-Client-ID", "CLIENT_VALUE");
+                httpHeaders.add("CF-Access-Client-Secret", "SECRET_VALUE");
+                httpRequest.headers().add(httpHeaders);
+            }
             return null;
         }
     });
@@ -115,4 +127,3 @@ environments {
 
 // To run the tests with all browsers just run “./gradlew test”
 baseUrl = "http://gebish.org"
-


### PR DESCRIPTION
Summary of the problem/fix:
Stepping blocks needs to bypass the authentication on crowdsegment application. For this, we need to inject some values on the http headers. To do this, we will use browsermob-core proxy. 

Selenium -> browsermob-core (modify headers)  -> crowsegment 

https://github.com/muuklabs/prototype/issues/1366

Tests executed:
Manual Test

Questions:
Does the PR have any dependency with BE or FE?
No
In case of a dependency, could you describe what would happen if not delivered together? (eg. FE will crash, code will not compile, etc)
Functionality will not work.

Did you add a new lib package (package.json)? If so, did you update the open source spreadsheet?
No, but we need new pip3 install pymongo[srv] on the server machine.

Did you link the defect to this PR (Github only)
Yes

If you are adding a new FE view or any significant UI change, have you shared the new UI to the team already?
No new views.

Did you include or update the unit tests?
No.

Did you execute the npm tests ?
Yes

Did you test it in both environments (dev/prod)?
No, only dev.

if you update the routes... Did you update the sample.txt ?
No update to routes