### PR TITLE
Domparser validations s98

### DIFF
--- a/CSSAnalyzer.py
+++ b/CSSAnalyzer.py
@@ -174,8 +174,8 @@ def parseImageSelector(selector, htmlElements, searchInfo, expectedIndex, tag):
    numberElementsFoundWithValue = 0
    expectedValue = searchInfo["value"]
 
-   for selector in htmlElements:
-      if(selector['src'] == expectedValue ):
+   for selectorImg in htmlElements:
+      if(selectorImg['src'] == expectedValue ):
          numberElementsFoundWithValue += 1
          indexesFound.append(index)
       index+=1   

--- a/domparser.py
+++ b/domparser.py
@@ -50,8 +50,17 @@ def createMuukReport(classname, browserName):
             element["feedback"] = []
             selectors =  json.loads(element.get("selectors").replace('\$', '\\\$'))
             selectorToUse = element.get("selectorToUse")
-            valueInfo = json.loads(element.get("value"))
-            attributes = json.loads(element.get("attributes"))
+            
+            try: 
+               valueInfo = json.loads(element.get("value"))
+            except Exception as ex:
+               valueInfo = {"value":"","":"href","":""}
+
+            try: 
+               attributes = json.loads(element.get("attributes"))
+            except Exception as ex:
+               attributes = {"id":"false","name":"undef","text":"","type":"undef"}
+
             attributes['value'] = valueInfo['value']
 
             for i in SELECTORS_ARRAY:
@@ -88,7 +97,13 @@ def createMuukReport(classname, browserName):
                                                 browserName,
                                                 attributes,
                                                 SELECTORS_ARRAY[i])                               
-               logging.info("Object  = " + json.dumps(domInfo,sort_keys=True, indent=4))
+               
+
+               try:
+                  logging.info("Object  = " + json.dumps(domInfo,sort_keys=True, indent=4))
+               except Exception as ex: 
+                  logging.error("Invalid domInfo generated") 
+
                if(domInfo):                                
                   element["feedback"].append(domInfo)
             steps.append(element)  


### PR DESCRIPTION
Problem: 
DOM Parser was not providing feedback on some tests as it generates exceptions and the parser stopped. 

Solution:
Use try/catch when loading json data and set default values in case of exception.  