### PR TITLE
Insights are not showed on successful tests

### DIFF
--- a/CSSAnalyzer.py
+++ b/CSSAnalyzer.py
@@ -174,8 +174,8 @@ def parseImageSelector(selector, htmlElements, searchInfo, expectedIndex, tag):
    numberElementsFoundWithValue = 0
    expectedValue = searchInfo["value"]
 
-   for selector in htmlElements:
-      if(selector['src'] == expectedValue ):
+   for element in htmlElements:
+      if(element['src'] == expectedValue or expectedValue.endswith(element['src'][2:None])):
          numberElementsFoundWithValue += 1
          indexesFound.append(index)
       index+=1   

--- a/CSSAnalyzer.py
+++ b/CSSAnalyzer.py
@@ -175,6 +175,8 @@ def parseImageSelector(selector, htmlElements, searchInfo, expectedIndex, tag):
    expectedValue = searchInfo["value"]
 
    for element in htmlElements:
+      # The element source sometimes comes with a relative path, so it starts with '../'.
+      # This is to remove the dots and compare against the end of expected value. 
       if(element['src'] == expectedValue or expectedValue.endswith(element['src'][2:None])):
          numberElementsFoundWithValue += 1
          indexesFound.append(index)

--- a/mkcli.py
+++ b/mkcli.py
@@ -51,8 +51,8 @@ def gatherFeedbackData(browserName):
           "failureMessage":  failureMessage,
           "muukReport":  {},
         }
-        if testSuccess == False :
-         testResult["muukReport"] = createMuukReport(testResult.get("className"), browserName)
+        # get and attach the report insights found during script execution
+        testResult["muukReport"] = createMuukReport(testResult.get("className"), browserName)
         
         feedbackData.append(testResult)
   else:


### PR DESCRIPTION
### Briefing
Having a test executed successfully does not show insights for steps as accurate. For instance, a script step may throw an exception nevertheless the execution could be successful if snippet is not for verification. This behavior is expected but we want to show in the step the insight about the exception thrown.


### Github Task
https://github.com/muuklabs/prototype/issues/1551

### Test executed

- Executed test with failing snippet (success and failing test)
- Executed test with success snippet (success and failing test)
- Executed test with both together, failing and successful snippet
- Executed test with all steps successful
- Executed test with some steps with warnings

### Answer the following questions
**Does the PR have any dependency with BE or FE? If so, specify which PR**
No
**In case of a dependency, could you describe what would happen if not delivered together? (eg. FE will crash, code will not compile, etc)**
NA
**Did you update the extension? if that's the case did you update the extension on remote Pupp project?**
No
**Did you add a new lib package (package.json)? If so, did you update the open source spreadsheet?**
No
**Did you link the defect to this PR (Github only)**
NA, different repository: https://github.com/muuklabs/prototype/issues/1551
**If you are adding a new FE view or any significant UI change, have you shared the new UI to the team already?**
NA
**Did you include or update the unit tests?**
NA
**Did you execute the npm tests ?**
Yes
**Did you test it in both environments (dev/prod)?**
Dev/Testing stage
**If you update the routes... Did you update the sample.txt ?**
NA
**Did you execute the E2E ?**
Yes
**Did you create new E2E tests or modified existing ones?**
No
**Did you add the new tests or modifications to the spreadsheet?**
No
**What tags are you using?**
NA
**What test tags were affected?**
NA