### PR TITLE
Add javafaker implemetation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,6 +42,8 @@ dependencies {
 
     compile group: 'org.seleniumhq.selenium', name: 'selenium-support', version: '3.14.0'
 
+    implementation 'com.github.javafaker:javafaker:1.0.2'
+
 }
 
 webdriverBinaries {

--- a/mkcli.py
+++ b/mkcli.py
@@ -99,7 +99,7 @@ def run(args):
   token=''
   try:
     key_file = open(path,'r')
-    key = key_file.read()
+    key = key_file.read().strip()
     r = requests.post(muuktestRoute+"generate_token_executer", data={'key': key})
     #r = requests.post(muuktestRoute+"generate_token_executer", data={'key': key}, verify=False)
     responseObject = json.loads(r.content)


### PR DESCRIPTION
**This PR is to be merged only on videoEnabled branch**

Summary of the problem/fix:
We need to add a new line for javaker on videoEnabled branch in order to continue working. This branch is useful for our CICD process running selenium as they work with a docker image which matches with the videoEnabled settings.

Questions:
Does the PR have any dependency with BE or FE?
no

In case of a dependency, could you describe what would happen if not delivered together? (eg. FE will crash, code will not compile, etc)
No dependency

Did you add a new lib package (package.json)? If so, did you update the open source spreadsheet?
No.

Did you link the defect to this PR (Github only)
NA

If you are adding a new FE view or any significant UI change, have you shared the new UI to the team already?
no

Did you include or update the unit tests?
No.

Did you execute the npm tests ?
NA

Did you test it in both environments (dev/prod)?
NA

if you update the routes... Did you update the sample.txt ?
No